### PR TITLE
Template not found msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The intent is that all of the basic options from Leiningen's `new` task are supp
 
 Boot templates are very similar to Leiningen templates but have an artifact name based on `boot-template` instead of `lein-template` and uses `boot` instead of `leiningen` in all the namespace names. In particular the `boot.new.templates` namespace provides functions such as `renderer` and `->files` that are the equivalent of the ones found in `leiningen.new.templates` when writing a Leiningen Template. The built-in templates are Boot templates, that produce Boot projects.
 
+To develop a new template, run `boot -d boot/new -t template -n my-template`.  This will generate a project whose `build.boot` has `(def project 'my-template/boot-template)`, with version `0.1.0-SNAPSHOT`. To test it, you will need to build and install it locally (the generated `build.boot` contains a `build` task for this purpose) and then use it to create a project, using either `--snapshot` or `--template-version` so `boot-new` will know which version to use.
+
 ### Arguments
 
 Previous sections have revealed that it is possible to pass arguments to templates. For multiple arguments, use one `-a` for each argument. For example:

--- a/src/boot/new_helpers.clj
+++ b/src/boot/new_helpers.clj
@@ -64,9 +64,9 @@
             (when (> *debug* 1)
               (clojure.stacktrace/print-cause-trace e)))
           (util/exit-error (println "Could not load template, failed with:" (.getMessage e)))))
-      (do (util/fail "Unable to locate template artifact, tried coordinates:\n\t[%s \"%s\"]\n\t[%s \"%s\"]\n"
-                     boot-name boot-version lein-name lein-version)
-          (System/exit 0))
+      (do
+        (util/fail "Unable to locate template artifact, tried coordinates:\n\t[%s \"%s\"]\n\t[%s \"%s\"]\n" boot-name boot-version lein-name lein-version)
+        (util/exit-error))
       )))
 
 (defn resolve-template


### PR DESCRIPTION
retain util/fail for error message (for the color formatting), but revert to util/exit-error instead of System/exit