### PR TITLE
Fix for boot-clj/boot-new#45

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,6 +1,6 @@
 (set-env! :resource-paths #{"src"})
 
-(def version "0.5.3")
+(def version "0.5.4")
 
 (task-options!
  pom {:project     'boot/new

--- a/src/boot/new/task/build.boot
+++ b/src/boot/new/task/build.boot
@@ -1,8 +1,7 @@
 (def project '{{raw-name}})
 (def version "0.1.0-SNAPSHOT")
 
-(set-env! :resource-paths #{"resources" "src"}
-          :source-paths   #{"test"}
+(set-env! :resource-paths #{"src"}
           :dependencies   '[[org.clojure/clojure "RELEASE"]
                             [boot/core "RELEASE" :scope "test"]
                             [adzerk/boot-test "RELEASE" :scope "test"]])


### PR DESCRIPTION
## Fix:
- Removed the resources folder and the test folder being referred in the task template.

## Rationale:

- We are not creating `resources` and `test` folder in type `task`. Which (I believe) is typically not required as well. So removed those files being referred from the templates `build.boot`.

## Testing:

Installed the changes in my local by running `boot build`. And ran the below command,
`boot -d boot/new new -t task -n new-task`
Under `new-task` project, the `build.boot` doesn't have references for the above mentioned folders. Also I'm able to run `boot --help` without any error.